### PR TITLE
chore: update paddlepaddle version requirement to >=2.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "surya-ocr==0.14.6",
     "protobuf==3.20.2",
     "paddleocr==2.8.1",
-    "paddlepaddle==2.6.1",
+    "paddlepaddle>=2.6.2",
     "torch==2.7.1",
     "torchvision==0.22.1",
     "transformers==4.53.2",


### PR DESCRIPTION
- Changed from ==2.6.1 to >=2.6.2 for better compatibility
- Allows installation with newer paddlepaddle versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated paddlepaddle dependency to support version 2.6.2 and higher, replacing the fixed version constraint with a minimum version requirement to enable compatibility with newer releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->