### PR TITLE
LayoutOutput enhancement

### DIFF
--- a/omnidocs/tasks/layout_extraction/models.py
+++ b/omnidocs/tasks/layout_extraction/models.py
@@ -506,26 +506,108 @@ class LayoutOutput(BaseModel):
     @classmethod
     def from_json(cls, json_str: str) -> "LayoutOutput":
         """
-        Create layout output from a JSON string.
-        Pydantic's model_validate_json handles the nested LayoutBox
-        and BoundingBox conversion automatically.
+        Create a LayoutOutput instance from a JSON string.
+
+        Deserializes a JSON string back into a LayoutOutput object with all
+        nested LayoutBox and BoundingBox objects properly reconstructed.
+        Pydantic's model_validate_json handles the nested object conversion
+        automatically.
+
+        Args:
+            json_str: JSON string representation of a LayoutOutput object.
+
+        Returns:
+            LayoutOutput: Deserialized layout output instance.
+
+        Raises:
+            ValueError: If JSON string is invalid or doesn't match expected schema.
+            ValidationError: If deserialized data fails model validation.
+
+        Example:
+            >>> json_data = '{"bboxes": [], "image_width": 800, "image_height": 600}'
+            >>> output = LayoutOutput.from_json(json_data)
+            >>> print(output.image_width)
+            800
         """
         return cls.model_validate_json(json_str)
 
     @classmethod
     def load_json(cls, file_path: Union[str, Path]) -> "LayoutOutput":
         """
-        Load layout output from a JSON file.
+        Load a LayoutOutput instance from a JSON file.
+
+        Reads a JSON file and deserializes its contents into a LayoutOutput object.
+        Handles file I/O with proper encoding and delegates deserialization to
+        the from_json method.
+
+        Args:
+            file_path: Path to JSON file containing serialized LayoutOutput data.
+                      Can be string or pathlib.Path object.
+
+        Returns:
+            LayoutOutput: Deserialized layout output instance from file.
+
+        Raises:
+            FileNotFoundError: If the specified file does not exist.
+            UnicodeDecodeError: If file cannot be decoded as UTF-8.
+            ValueError: If file contents are not valid JSON.
+            ValidationError: If JSON data doesn't match LayoutOutput schema.
+
+        Example:
+            >>> output = LayoutOutput.load_json('layout_results.json')
+            >>> print(f"Found {output.element_count} elements")
+            Found 5 elements
         """
         path = Path(file_path)
         return cls.from_json(path.read_text(encoding="utf-8"))
 
     def to_json(self) -> str:
-        """Helper to match your test: converts object to JSON string."""
+        """
+        Convert LayoutOutput instance to a JSON string.
+
+        Serializes the LayoutOutput object and all nested LayoutBox and BoundingBox
+        objects into a JSON string representation. Uses Pydantic's model_dump_json
+        for reliable serialization with proper handling of enums and custom types.
+
+        Returns:
+            str: JSON string representation of the LayoutOutput object.
+
+        Example:
+            >>> output = LayoutOutput(bboxes=[], image_width=800, image_height=600)
+            >>> json_str = output.to_json()
+            >>> print(type(json_str))
+            <class 'str'>
+            >>> print('image_width' in json_str)
+            True
+        """
         return self.model_dump_json()
 
     def save_json(self, file_path: Union[str, Path]) -> None:
-        """Helper to match your test: saves object to JSON file."""
+        """
+        Save LayoutOutput instance to a JSON file.
+
+        Serializes the LayoutOutput object to JSON and writes it to a file.
+        Automatically creates parent directories if they don't exist. Uses UTF-8
+        encoding for compatibility and proper handling of special characters.
+
+        Args:
+            file_path: Path where JSON file should be saved. Can be string or
+                      pathlib.Path object. Parent directories will be created
+                      if they don't exist.
+
+        Returns:
+            None
+
+        Raises:
+            OSError: If file cannot be written due to permission or disk errors.
+            TypeError: If file_path is not a string or Path object.
+
+        Example:
+            >>> output = LayoutOutput(bboxes=[], image_width=800, image_height=600)
+            >>> output.save_json('results/layout_output.json')
+            >>> # File is created at results/layout_output.json
+            >>> # Parent 'results' directory is created if it didn't exist
+        """
         path = Path(file_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(self.to_json(), encoding="utf-8")

--- a/tests/tasks/layout_extraction/test_models.py
+++ b/tests/tasks/layout_extraction/test_models.py
@@ -336,6 +336,7 @@ class TestLayoutOutput:
         assert d["labels_found"] == ["title"]
 
     def test_layout_save_json(self, tmp_path):
+        """Test saving LayoutOutput to JSON file."""
         boxes = [
             LayoutBox(
                 label=LayoutLabel.TITLE,
@@ -361,6 +362,7 @@ class TestLayoutOutput:
             assert "bboxes" in content
 
     def test_layout_to_json(self):
+        """Test converting LayoutOutput to JSON string."""
         boxes = [
             LayoutBox(
                 label=LayoutLabel.TITLE,
@@ -383,6 +385,7 @@ class TestLayoutOutput:
         assert "bboxes" in json_str
 
     def test_layout_from_json(self):
+        """Test creating LayoutOutput from JSON string."""
         boxes = [
             LayoutBox(
                 label=LayoutLabel.TITLE,
@@ -406,6 +409,7 @@ class TestLayoutOutput:
         assert len(new_output.bboxes) == len(output.bboxes)
 
     def test_layout_load_json(self, tmp_path):
+        """Test loading LayoutOutput from JSON file."""
         boxes = [
             LayoutBox(
                 label=LayoutLabel.TITLE,


### PR DESCRIPTION
## Description
Added methods to export LayoutOutput results to JSON format for easy serialization and integration with other tools.

## Related Issues
#24

## Changes Made
- added from_json to return a LayoutOutput object
- added load_json to read json file and return a LayoutOutput object
- added to_json to return LayoutOutput object as json dictionary
-  added save_json to save the the LayoutOutput to json file

## Testing
- [x] Tests added/updated
- [x] All tests passing locally (`uv run pytest tests/ -v`)
- [x] Linting passes (`uv run ruff check .`)

## Checklist
- [x] Code follows project style guidelines
- [x] CONTRIBUTING.md guidelines followed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON import/export for layout extraction results so users can save outputs to files, reload them, and exchange results as JSON strings.

* **Tests**
  * Added tests verifying JSON serialization and deserialization, covering save/load and string-based workflows to ensure core layout fields and bounding boxes are preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->