### PR TITLE
feat: Add __repr__ methods to layout extraction models

### DIFF
--- a/omnidocs/tasks/layout_extraction/models.py
+++ b/omnidocs/tasks/layout_extraction/models.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
+
 if TYPE_CHECKING:
     from PIL import Image
 
@@ -268,6 +269,7 @@ class BoundingBox(BaseModel):
         )
 
     def to_absolute(self, image_width: int, image_height: int) -> "BoundingBox":
+
         """
         Convert from normalized (0-1024) to absolute pixel coordinates.
 
@@ -284,6 +286,19 @@ class BoundingBox(BaseModel):
             x2=self.x2 / NORMALIZED_SIZE * image_width,
             y2=self.y2 / NORMALIZED_SIZE * image_height,
         )
+
+    def __repr_args__(self):
+        def fmt(v):
+            return int(v) if float(v).is_integer() else v
+        
+        return [
+            ("x1", fmt(self.x1)),
+            ("y1", fmt(self.y1)),
+            ("x2", fmt(self.x2)),
+            ("y2", fmt(self.y2)),
+            ("width", fmt(self.width)),
+            ("height", fmt(self.height)),
+        ]
 
 
 # ============= Layout Box Model =============
@@ -325,6 +340,17 @@ class LayoutBox(BaseModel):
         """
         return self.bbox.to_normalized(image_width, image_height)
 
+    def __repr_args__(self):
+        def fmt(v):
+            return int(v) if isinstance(v, float) and v.is_integer() else v
+        
+        bbox_list = [fmt(v) for v in self.bbox.to_list()]
+
+        return [
+            ("label", self.label.value),
+            ("confidence", round(self.confidence, 3)),
+            ("bbox", bbox_list),
+        ]
 
 # ============= Visualization Colors =============
 
@@ -358,6 +384,13 @@ class LayoutOutput(BaseModel):
     model_name: Optional[str] = Field(default=None, description="Name of the model used")
 
     model_config = ConfigDict(extra="forbid")
+
+    def __repr_args__(self):
+        return [
+            ("elements", len(self.bboxes)),
+            ("labels", self.labels_found),
+            ("image_size", (self.image_width, self.image_height)),
+        ]
 
     @property
     def element_count(self) -> int:

--- a/omnidocs/tasks/layout_extraction/models.py
+++ b/omnidocs/tasks/layout_extraction/models.py
@@ -269,7 +269,6 @@ class BoundingBox(BaseModel):
         )
 
     def to_absolute(self, image_width: int, image_height: int) -> "BoundingBox":
-
         """
         Convert from normalized (0-1024) to absolute pixel coordinates.
 


### PR DESCRIPTION
## Summary
Adds readable __repr__ output for BoundingBox, LayoutBox, and LayoutOutput
using Pydantic v2 __repr_args__ hooks.

## Motivation
Improves debugging and developer experience when inspecting layout
extraction outputs.

## Changes
- Added Pydantic v2-friendly __repr_args__ implementations
- Included computed fields where relevant
- Omitted noisy internal fields
- No functional or behavioral changes

Closes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal formatting of layout-detection outputs for clearer debugging and logs: bounding-box coordinates are presented compactly, item labels and confidences are easier to read, and overall output summaries show element counts and image size more clearly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->