### PR TITLE
Test: add remaining layout extraction edge case tests

### DIFF
--- a/tests/tasks/layout_extraction/test_doc_layout_yolo.py
+++ b/tests/tasks/layout_extraction/test_doc_layout_yolo.py
@@ -191,7 +191,7 @@ class TestDocLayoutYOLOEdgeCases:
 
         with pytest.raises(ValueError):
             extractor.extract({"invalid": "type"})
-            
+
     def test_grayscale_image(self):
         """Test extraction on grayscale image."""
         config = DocLayoutYOLOConfig(device="cpu")


### PR DESCRIPTION
## Description
Add remaining edge case tests for the layout extraction module to improve robustness and ensure consistent behavior across extractors.

## Related Issues
Closes #22

## Changes Made
- Added grayscale image input tests for DocLayoutYOLO and RT-DETR
- Added RGBA (alpha channel) image input tests for DocLayoutYOLO and RT-DETR
- Added confidence threshold edge case tests (0.0 and 1.0) for both extractors

## Testing
- [x] Tests added/updated
- [x] All tests passing locally (`uv run pytest tests/tasks/layout_extraction/ -v`)
- [x] Linting passes (`uv run ruff check .`)

## Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated
- [x] CONTRIBUTING.md guidelines followed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for document and RTDETR layout extraction with new test cases covering grayscale images, RGBA images, and various confidence threshold configurations.
  * Added model-availability guards to ensure tests run only when dependencies are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->