### PR TITLE
feat: Microsoft TATR integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ poetry.lock
 # # Ignore models directory but not docs/models
 # models/
 # !docs/models/
+
+results/

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ html = result.to_html()
 | **Nanonets OCR2** | PyTorch, VLLM, MLX | Fast, accurate |
 | **Granite Docling** | PyTorch, VLLM, MLX, API | IBM research model |
 | **DotsOCR** | PyTorch, VLLM, API | Layout-aware |
+| **LightOn** | PyTorch, VLLM, MLX | High-speed document-to-markdown |
+| **GLM-OCR** | PyTorch, VLLM, MLX | Very Fast and accurate |
+| **Deepseek** | PyTorch, VLLM, MLX, API | Layout-aware document reasoning |
 
 ### Layout Analysis
 
@@ -232,6 +235,7 @@ html = result.to_html()
 | Model | Backends | Notes |
 |-------|----------|-------|
 | **TableFormer** | PyTorch | Structure + content |
+| **Microsoft TATR** | PyTorch,ONNX | DETR-based structure recognition |
 
 ### Reading Order
 

--- a/docs/tasks/table-extraction.md
+++ b/docs/tasks/table-extraction.md
@@ -9,6 +9,7 @@ Extract structured data from tables in document images.
 | Model | Speed | Output | Backends |
 |-------|-------|--------|----------|
 | **TableFormer** | 0.5-1s/table | Cells, rows, columns, spans | PyTorch |
+| **Microsoft TATR** | 0.2-0.6s/page | Table detection & structure | PyTorch, ONNX |
 
 ---
 

--- a/omnidocs/tasks/table_extraction/__init__.py
+++ b/omnidocs/tasks/table_extraction/__init__.py
@@ -44,6 +44,7 @@ from .models import (
     TableOutput,
 )
 from .tableformer import TableFormerConfig, TableFormerExtractor, TableFormerMode
+from .tatr import TATRExtractor, TATRONNXConfig, TATRPyTorchConfig, TATRVariant
 
 __all__ = [
     # Base
@@ -58,4 +59,9 @@ __all__ = [
     "TableFormerExtractor",
     "TableFormerConfig",
     "TableFormerMode",
+    # TATR
+    "TATRExtractor",
+    "TATRPyTorchConfig",
+    "TATRONNXConfig",
+    "TATRVariant",
 ]

--- a/omnidocs/tasks/table_extraction/tatr/__init__.py
+++ b/omnidocs/tasks/table_extraction/tatr/__init__.py
@@ -1,0 +1,15 @@
+"""
+TATR (Table Transformer) module for table structure extraction.
+
+Provides Microsoft's Table Transformer with two backends: PyTorch and ONNX.
+"""
+
+from .config import TATRONNXConfig, TATRPyTorchConfig, TATRVariant
+from .extractor import TATRExtractor
+
+__all__ = [
+    "TATRExtractor",
+    "TATRPyTorchConfig",
+    "TATRONNXConfig",
+    "TATRVariant",
+]

--- a/omnidocs/tasks/table_extraction/tatr/config.py
+++ b/omnidocs/tasks/table_extraction/tatr/config.py
@@ -1,0 +1,135 @@
+"""
+Configuration for Table Transformer (TATR) table structure extractor.
+
+TATR is a DETR-based object detection model from Microsoft that detects
+table rows, columns, and cell bounding boxes from document images.
+
+Example:
+```python
+    from omnidocs.tasks.table_extraction.tatr import TATRConfig, TATRVariant
+
+    # PyTorch backend
+    from omnidocs.tasks.table_extraction.tatr import TATRPyTorchConfig
+    extractor = TATRExtractor(backend=TATRPyTorchConfig(variant=TATRVariant.ALL))
+
+    # ONNX backend
+    from omnidocs.tasks.table_extraction.tatr import TATRONNXConfig
+    extractor = TATRExtractor(backend=TATRONNXConfig())
+```
+"""
+
+from enum import Enum
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TATRVariant(str, Enum):
+    """
+    TATR model variant.
+
+    PUB  - Trained on PubTables-1M (scientific/academic documents)
+    FIN  - Trained on FinTabNet.c (financial documents, dense numeric tables)
+    ALL  - Trained on both PubTables-1M + FinTabNet.c (general purpose)
+    """
+
+    PUB = "pub"
+    FIN = "fin"
+    ALL = "all"
+
+
+_VARIANT_REPO = {
+    TATRVariant.PUB: "microsoft/table-transformer-structure-recognition",
+    TATRVariant.FIN: "microsoft/table-transformer-structure-recognition-v1.1-fin",
+    TATRVariant.ALL: "microsoft/table-transformer-structure-recognition-v1.1-all",
+}
+
+
+class TATRPyTorchConfig(BaseModel):
+    """
+        PyTorch/HuggingFace backend config for TATR.
+
+        Example:
+    ```python
+            from omnidocs.tasks.table_extraction import TATRExtractor
+            from omnidocs.tasks.table_extraction.tatr import TATRPyTorchConfig, TATRVariant
+
+            extractor = TATRExtractor(backend=TATRPyTorchConfig(
+                variant=TATRVariant.ALL,
+                device="cuda",
+            ))
+            result = extractor.extract(table_image)
+    ```
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    variant: TATRVariant = Field(
+        default=TATRVariant.ALL,
+        description="Model variant: 'pub' (scientific), 'fin' (financial), 'all' (general)",
+    )
+    device: Literal["cpu", "cuda", "mps", "auto"] = Field(
+        default="auto",
+        description="Device for inference",
+    )
+    detection_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Confidence threshold for detections",
+    )
+    cache_dir: Optional[str] = Field(
+        default=None,
+        description="Model cache directory. If None, uses OMNIDOCS_MODELS_DIR env var or default cache.",
+    )
+
+    @property
+    def repo_id(self) -> str:
+        return _VARIANT_REPO[self.variant]
+
+
+class TATRONNXConfig(BaseModel):
+    """
+        ONNX Runtime backend config for TATR.
+
+        Runs without PyTorch. Uses onnxruntime (CPU) or onnxruntime-gpu (CUDA).
+        The ONNX model is exported on first use and cached to disk.
+
+        Example:
+    ```python
+            from omnidocs.tasks.table_extraction import TATRExtractor
+            from omnidocs.tasks.table_extraction.tatr import TATRONNXConfig, TATRVariant
+
+            extractor = TATRExtractor(backend=TATRONNXConfig(
+                variant=TATRVariant.FIN,
+                use_gpu=False,
+            ))
+            result = extractor.extract(table_image)
+    ```
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    variant: TATRVariant = Field(
+        default=TATRVariant.ALL,
+        description="Model variant: 'pub' (scientific), 'fin' (financial), 'all' (general)",
+    )
+    use_gpu: bool = Field(
+        default=False,
+        description="Use CUDAExecutionProvider if True, else CPUExecutionProvider",
+    )
+    detection_threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Confidence threshold for detections",
+    )
+    cache_dir: Optional[str] = Field(
+        default=None,
+        description="Directory to cache the exported ONNX model file. "
+        "If None, uses OMNIDOCS_MODELS_DIR env var or default cache.",
+    )
+
+    @property
+    def repo_id(self) -> str:
+        return _VARIANT_REPO[self.variant]

--- a/omnidocs/tasks/table_extraction/tatr/extractor.py
+++ b/omnidocs/tasks/table_extraction/tatr/extractor.py
@@ -1,0 +1,85 @@
+"""
+TATRExtractor — unified entry point that dispatches to the correct backend.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import numpy as np
+from PIL import Image
+
+from omnidocs.tasks.table_extraction.base import BaseTableExtractor
+from omnidocs.tasks.table_extraction.models import TableOutput
+
+from .config import TATRONNXConfig, TATRPyTorchConfig
+from .onnx import TATRONNXExtractor
+from .pytorch import TATRPyTorchExtractor
+
+if TYPE_CHECKING:
+    from omnidocs.tasks.ocr_extraction.models import OCROutput
+
+TATRBackendConfig = Union[TATRPyTorchConfig, TATRONNXConfig]
+
+
+class TATRExtractor(BaseTableExtractor):
+    """
+        Table Transformer (TATR) table structure extractor.
+
+        Supports three backends selectable via config type:
+          - TATRPyTorchConfig  → PyTorch / HuggingFace transformers (CPU, CUDA, MPS)
+          - TATRONNXConfig     → ONNX Runtime (CPU or CUDA, no PyTorch at inference)
+
+        Three model variants:
+          - TATRVariant.PUB  — scientific/academic documents (PubTables-1M)
+          - TATRVariant.FIN  — financial documents (FinTabNet.c)
+          - TATRVariant.ALL  — general purpose (both datasets, recommended default)
+
+        Example:
+    ```python
+            from omnidocs.tasks.table_extraction import TATRExtractor
+            from omnidocs.tasks.table_extraction.tatr import (
+                TATRPyTorchConfig,
+                TATRONNXConfig,
+                TATRVariant,
+            )
+
+            # PyTorch (GPU)
+            extractor = TATRExtractor(backend=TATRPyTorchConfig(device="cuda"))
+
+            # ONNX (CPU, no PyTorch at inference)
+            extractor = TATRExtractor(backend=TATRONNXConfig())
+
+            result = extractor.extract(table_image)
+            html = result.to_html()
+            df = result.to_dataframe()
+    ```
+    """
+
+    def __init__(self, backend: TATRBackendConfig):
+        self.backend_config = backend
+        self._impl: BaseTableExtractor = self._build_impl(backend)
+
+    def _build_impl(self, backend: TATRBackendConfig) -> BaseTableExtractor:
+        if isinstance(backend, TATRPyTorchConfig):
+            return TATRPyTorchExtractor(backend)
+        if isinstance(backend, TATRONNXConfig):
+            return TATRONNXExtractor(backend)
+        raise TypeError(f"Unknown TATR backend config: {type(backend)}")
+
+    def _load_model(self) -> None:
+        pass  # Handled in _build_impl
+
+    def extract(
+        self,
+        image: Union[Image.Image, np.ndarray, str, Path],
+        ocr_output: Optional["OCROutput"] = None,
+    ) -> TableOutput:
+        return self._impl.extract(image, ocr_output=ocr_output)
+
+    def batch_extract(
+        self,
+        images: List[Union[Image.Image, np.ndarray, str, Path]],
+        ocr_outputs=None,
+        progress_callback=None,
+    ) -> List[TableOutput]:
+        return self._impl.batch_extract(images, ocr_outputs, progress_callback)

--- a/omnidocs/tasks/table_extraction/tatr/onnx.py
+++ b/omnidocs/tasks/table_extraction/tatr/onnx.py
@@ -1,0 +1,221 @@
+"""
+TATR extractor — ONNX Runtime backend.
+
+Exports the HuggingFace TATR model to ONNX on first use (cached to disk),
+then runs inference with onnxruntime. No PyTorch required at inference time.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
+
+import numpy as np
+from PIL import Image
+
+from omnidocs.tasks.table_extraction.base import BaseTableExtractor
+from omnidocs.tasks.table_extraction.models import TableOutput
+from omnidocs.utils.cache import get_model_cache_dir
+
+from .config import TATRONNXConfig
+from .pytorch import _detections_to_table_output
+
+if TYPE_CHECKING:
+    from omnidocs.tasks.ocr_extraction.models import OCROutput
+
+# TATR standard input size
+_TATR_SIZE = (800, 800)
+
+# Label map for TATR structure recognition
+_TATR_ID2LABEL = {
+    0: "table",
+    1: "table column",
+    2: "table row",
+    3: "table column header",
+    4: "table projected row header",
+    5: "table spanning cell",
+    6: "no object",
+}
+
+# ImageNet normalisation (used by TATR processor)
+_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+
+def _get_onnx_path(config: TATRONNXConfig) -> Path:
+    cache_dir = get_model_cache_dir(config.cache_dir)
+    return cache_dir / f"tatr_{config.variant.value}.onnx"
+
+
+# def _export_onnx(config: TATRONNXConfig, onnx_path: Path) -> None:
+#     """Export the HuggingFace TATR model to ONNX. Requires torch + transformers."""
+#     try:
+#         import torch
+#         from transformers import TableTransformerForObjectDetection
+#     except ImportError:
+#         raise ImportError(
+#             "torch and transformers are required to export TATR to ONNX. "
+#             "Install with: pip install torch transformers\n"
+#             "After export, only onnxruntime is needed for inference."
+#         )
+
+
+#     cache_dir = str(get_model_cache_dir(config.cache_dir))
+#     model = TableTransformerForObjectDetection.from_pretrained(
+#         config.repo_id, cache_dir=cache_dir
+#     )
+def _export_onnx(config: TATRONNXConfig, onnx_path: Path) -> None:
+    """Export the HuggingFace TATR model to ONNX. Requires torch + transformers."""
+    try:
+        import torch
+        from transformers import TableTransformerForObjectDetection
+    except ImportError:
+        raise ImportError(
+            "torch and transformers are required to export TATR to ONNX. "
+            "Install with: pip install torch transformers\n"
+            "After export, only onnxruntime is needed for inference."
+        )
+
+    # Workaround: huggingface_hub >=0.24 strict validation rejects None for bool fields.
+    # TATR config.json has "dilation": null — patch _validate_simple_type to allow it.
+    try:
+        import huggingface_hub.dataclasses as _hf_dc
+
+        _orig = _hf_dc._validate_simple_type
+
+        def _patched(name, value, expected_type):
+            if value is None:
+                return
+            _orig(name, value, expected_type)
+
+        _hf_dc._validate_simple_type = _patched
+    except Exception:
+        pass
+
+    cache_dir = str(get_model_cache_dir(config.cache_dir))
+    model = TableTransformerForObjectDetection.from_pretrained(config.repo_id, cache_dir=cache_dir)
+    model.eval()
+
+    dummy = torch.zeros(1, 3, _TATR_SIZE[1], _TATR_SIZE[0])
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+
+    torch.onnx.export(
+        model,
+        ({"pixel_values": dummy},),
+        str(onnx_path),
+        input_names=["pixel_values"],
+        output_names=["logits", "pred_boxes"],
+        dynamic_axes={
+            "pixel_values": {0: "batch"},
+            "logits": {0: "batch"},
+            "pred_boxes": {0: "batch"},
+        },
+        opset_version=14,
+    )
+
+
+def _preprocess(pil_image: Image.Image) -> np.ndarray:
+    """Resize + normalise to TATR input format, returns (1, 3, H, W) float32."""
+    img = pil_image.resize(_TATR_SIZE, Image.BILINEAR)
+    arr = np.array(img, dtype=np.float32) / 255.0  # (H, W, 3)
+    arr = (arr - _MEAN) / _STD
+    arr = arr.transpose(2, 0, 1)[None]  # (1, 3, H, W)
+    return arr.astype(np.float32)
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _box_cxcywh_to_xyxy(boxes: np.ndarray) -> np.ndarray:
+    """Convert DETR center-format boxes to x1y1x2y2."""
+    cx, cy, w, h = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    return np.stack([cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2], axis=1)
+
+
+class TATRONNXExtractor(BaseTableExtractor):
+    """
+        TATR table structure extractor — ONNX Runtime backend.
+
+        Exports the TATR model to ONNX on first use (cached), then runs inference
+        via onnxruntime. No PyTorch dependency required at inference time.
+
+        Example:
+    ```python
+            from omnidocs.tasks.table_extraction import TATRExtractor
+            from omnidocs.tasks.table_extraction.tatr import TATRONNXConfig, TATRVariant
+
+            extractor = TATRExtractor(backend=TATRONNXConfig(
+                variant=TATRVariant.ALL,
+                use_gpu=False,
+            ))
+            result = extractor.extract(table_image)
+    ```
+    """
+
+    def __init__(self, config: TATRONNXConfig):
+        self.config = config
+        self._session = None
+        self._load_model()
+
+    def _load_model(self) -> None:
+        try:
+            import onnxruntime as ort
+        except ImportError:
+            raise ImportError(
+                "onnxruntime is required for TATRONNXExtractor. "
+                "Install with: pip install onnxruntime  (CPU)  or  pip install onnxruntime-gpu  (CUDA)"
+            )
+
+        onnx_path = _get_onnx_path(self.config)
+        if not onnx_path.exists():
+            _export_onnx(self.config, onnx_path)
+
+        providers = (
+            ["CUDAExecutionProvider", "CPUExecutionProvider"] if self.config.use_gpu else ["CPUExecutionProvider"]
+        )
+        self._session = ort.InferenceSession(str(onnx_path), providers=providers)
+
+    def extract(
+        self,
+        image: Union[Image.Image, np.ndarray, str, Path],
+        ocr_output: Optional["OCROutput"] = None,
+    ) -> TableOutput:
+        pil_image = self._prepare_image(image)
+        orig_w, orig_h = pil_image.size
+
+        pixel_values = _preprocess(pil_image)
+
+        logits, pred_boxes = self._session.run(
+            ["logits", "pred_boxes"],
+            {"pixel_values": pixel_values},
+        )
+        # logits: (1, num_queries, num_classes)  pred_boxes: (1, num_queries, 4) cxcywh normed
+        logits = logits[0]  # (Q, C)
+        pred_boxes = pred_boxes[0]  # (Q, 4)
+
+        probs = _sigmoid(logits)  # (Q, C)
+        scores = probs.max(axis=1)  # (Q,)
+        label_ids = probs.argmax(axis=1)  # (Q,)
+
+        # Filter by threshold and exclude "no object" (last class)
+        no_obj_idx = logits.shape[1] - 1
+        keep = (scores >= self.config.detection_threshold) & (label_ids != no_obj_idx)
+
+        kept_scores = scores[keep].tolist()
+        kept_labels = label_ids[keep].tolist()
+
+        # Denormalise boxes to original image pixels
+        boxes_xyxy = _box_cxcywh_to_xyxy(pred_boxes[keep])
+        boxes_xyxy[:, [0, 2]] *= orig_w
+        boxes_xyxy[:, [1, 3]] *= orig_h
+        kept_boxes = boxes_xyxy.tolist()
+
+        return _detections_to_table_output(
+            boxes=kept_boxes,
+            scores=kept_scores,
+            labels=kept_labels,
+            image_width=orig_w,
+            image_height=orig_h,
+            ocr_output=ocr_output,
+            model_name=f"TATR-{self.config.variant.value}-onnx",
+            label_map=_TATR_ID2LABEL,
+        )

--- a/omnidocs/tasks/table_extraction/tatr/pytorch.py
+++ b/omnidocs/tasks/table_extraction/tatr/pytorch.py
@@ -1,0 +1,303 @@
+"""
+TATR extractor — PyTorch/HuggingFace Transformers backend.
+
+Uses TableTransformerForObjectDetection from the transformers library.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+import numpy as np
+from PIL import Image
+
+from omnidocs.cache import add_reference, get_cache_key, get_cached, set_cached
+from omnidocs.tasks.table_extraction.base import BaseTableExtractor
+from omnidocs.tasks.table_extraction.models import (
+    BoundingBox,
+    CellType,
+    TableCell,
+    TableOutput,
+)
+from omnidocs.utils.cache import get_model_cache_dir
+
+from .config import TATRPyTorchConfig
+
+if TYPE_CHECKING:
+    from omnidocs.tasks.ocr_extraction.models import OCROutput
+
+# TATR label index → semantic meaning
+_TATR_LABELS = {
+    0: "table",
+    1: "table column",
+    2: "table row",
+    3: "table column header",
+    4: "table projected row header",
+    5: "table spanning cell",
+    6: "no object",
+}
+
+
+def _resolve_device(device: str) -> str:
+    if device == "auto":
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                return "cuda"
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                return "mps"
+        except ImportError:
+            pass
+        return "cpu"
+    return device
+
+
+class TATRPyTorchExtractor(BaseTableExtractor):
+    """
+        TATR table structure extractor — PyTorch backend.
+
+        Uses Microsoft's Table Transformer (TATR) via HuggingFace transformers.
+        Detects rows, columns, column headers, spanning cells, and projected
+        row headers as object detections, then reconstructs the cell grid.
+
+        Example:
+    ```python
+            from omnidocs.tasks.table_extraction import TATRExtractor
+            from omnidocs.tasks.table_extraction.tatr import TATRPyTorchConfig, TATRVariant
+
+            extractor = TATRExtractor(backend=TATRPyTorchConfig(
+                variant=TATRVariant.ALL,
+                device="cuda",
+            ))
+            result = extractor.extract(table_image)
+            df = result.to_dataframe()
+    ```
+    """
+
+    def __init__(self, config: TATRPyTorchConfig):
+        self.config = config
+        self._device = _resolve_device(config.device)
+        self._model = None
+        self._processor = None
+        self._load_model()
+
+    def _load_model(self) -> None:
+        cache_key = get_cache_key(self.config)
+        self._cache_key = cache_key
+        cached = get_cached(cache_key)
+        if cached is not None:
+            self._model, self._processor = cached
+            add_reference(cache_key, self)
+            return
+
+        try:
+            from transformers import AutoImageProcessor, TableTransformerForObjectDetection
+        except ImportError:
+            raise ImportError(
+                "transformers is required for TATRPyTorchExtractor. Install with: pip install transformers"
+            )
+
+        cache_dir = str(get_model_cache_dir(self.config.cache_dir))
+
+        # ---------------------------------------------------------------
+        # Workaround: huggingface_hub >=0.24 introduced strict dataclass
+        # validation. The TATR config.json has "dilation": null which
+        # fails bool validation during cls(**config_dict). We patch
+        # __strict_setattr__ to coerce None → False for bool fields
+        # before ANY from_pretrained call fires the validator.
+        # ---------------------------------------------------------------
+        try:
+            import huggingface_hub.dataclasses as _hf_dc
+
+            _orig_validate_simple = _hf_dc._validate_simple_type
+
+            def _patched_validate_simple(name, value, expected_type):
+                if value is None:
+                    return  # Allow None through — mirrors Optional[T] semantics
+                _orig_validate_simple(name, value, expected_type)
+
+            _hf_dc._validate_simple_type = _patched_validate_simple
+        except Exception:
+            pass
+
+        self._processor = AutoImageProcessor.from_pretrained(
+            self.config.repo_id,
+            cache_dir=cache_dir,
+        )
+
+        # Workaround: TATR preprocessor_config.json has {"longest_edge": 800, "shortest_edge": null}.
+        # transformers>=5.x DetrImageProcessor.resize() requires both to be non-None.
+        # Set shortest_edge = longest_edge to preserve original aspect-ratio resize behaviour.
+        proc_size = self._processor.size
+        if isinstance(proc_size, dict):
+            longest = proc_size.get("longest_edge")
+            if longest is not None and proc_size.get("shortest_edge") is None:
+                self._processor.size = {"shortest_edge": longest, "longest_edge": longest}
+        else:
+            # SizeDict object — set attributes directly
+            if (
+                getattr(proc_size, "longest_edge", None) is not None
+                and getattr(proc_size, "shortest_edge", None) is None
+            ):
+                proc_size.shortest_edge = proc_size.longest_edge
+        self._model = TableTransformerForObjectDetection.from_pretrained(
+            self.config.repo_id,
+            cache_dir=cache_dir,
+        )
+        self._model = self._model.to(self._device)
+        self._model.eval()
+
+        set_cached(cache_key, (self._model, self._processor), owner=self)
+
+    def extract(
+        self,
+        image: Union[Image.Image, np.ndarray, str, Path],
+        ocr_output: Optional["OCROutput"] = None,
+    ) -> TableOutput:
+        import torch
+
+        pil_image = self._prepare_image(image)
+        width, height = pil_image.size
+
+        inputs = self._processor(images=pil_image, return_tensors="pt")
+        inputs = {k: v.to(self._device) for k, v in inputs.items()}
+
+        with torch.no_grad():
+            outputs = self._model(**inputs)
+
+        target_sizes = torch.tensor([[height, width]], device=self._device)
+        results = self._processor.post_process_object_detection(
+            outputs,
+            threshold=self.config.detection_threshold,
+            target_sizes=target_sizes,
+        )[0]
+
+        boxes = results["boxes"].cpu().tolist()
+        scores = results["scores"].cpu().tolist()
+        labels = results["labels"].cpu().tolist()
+
+        return _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=width,
+            image_height=height,
+            ocr_output=ocr_output,
+            model_name=f"TATR-{self.config.variant.value}",
+            label_map=self._model.config.id2label,
+        )
+
+
+def _detections_to_table_output(
+    boxes: List[List[float]],
+    scores: List[float],
+    labels: List[int],
+    image_width: int,
+    image_height: int,
+    ocr_output: Optional["OCROutput"],
+    model_name: str,
+    label_map: dict,
+) -> TableOutput:
+    """
+    Convert TATR object detections into a structured TableOutput.
+
+    TATR detects rows and columns as separate bounding boxes.
+    We reconstruct cells by finding all (row, col) intersections.
+    """
+    rows: List[Tuple[float, float, float, float]] = []  # (x1, y1, x2, y2)
+    cols: List[Tuple[float, float, float, float]] = []
+    col_headers: List[bool] = []  # parallel to rows — is this row a col header?
+
+    for box, score, label_idx in zip(boxes, scores, labels):
+        label_str = label_map.get(label_idx, "")
+        x1, y1, x2, y2 = box
+        if label_str == "table row":
+            rows.append((x1, y1, x2, y2))
+        elif label_str == "table column":
+            cols.append((x1, y1, x2, y2))
+        elif label_str == "table column header":
+            rows.append((x1, y1, x2, y2))
+            col_headers.append(True)
+        # spanning cells and projected row headers are noted but cell
+        # reconstruction handles them via overlap logic below
+
+    if not rows or not cols:
+        return TableOutput(
+            cells=[],
+            num_rows=0,
+            num_cols=0,
+            image_width=image_width,
+            image_height=image_height,
+            model_name=model_name,
+        )
+
+    # Sort rows top-to-bottom, cols left-to-right
+    rows.sort(key=lambda b: b[1])
+    cols.sort(key=lambda b: b[0])
+
+    # Build a set of column-header row y-ranges for fast lookup
+    header_y_ranges = set()
+    for box, score, label_idx in zip(boxes, scores, labels):
+        label_str = label_map.get(label_idx, "")
+        if label_str == "table column header":
+            header_y_ranges.add((box[1], box[3]))
+
+    cells: List[TableCell] = []
+
+    # Build OCR word lookup if provided
+    ocr_words = []
+    if ocr_output:
+        for block in ocr_output.text_blocks:
+            ocr_words.append((block.bbox.x1, block.bbox.y1, block.bbox.x2, block.bbox.y2, block.text))
+
+    for row_idx, row_box in enumerate(rows):
+        rx1, ry1, rx2, ry2 = row_box
+        is_header = any(abs(ry1 - hy1) < 5 and abs(ry2 - hy2) < 5 for hy1, hy2 in header_y_ranges)
+        cell_type = CellType.COLUMN_HEADER if is_header else CellType.DATA
+
+        for col_idx, col_box in enumerate(cols):
+            cx1, cy1, cx2, cy2 = col_box
+
+            # Cell bbox is the intersection of row and column
+            cell_x1 = max(rx1, cx1)
+            cell_y1 = max(ry1, cy1)
+            cell_x2 = min(rx2, cx2)
+            cell_y2 = min(ry2, cy2)
+
+            if cell_x2 <= cell_x1 or cell_y2 <= cell_y1:
+                continue
+
+            bbox = BoundingBox(x1=cell_x1, y1=cell_y1, x2=cell_x2, y2=cell_y2)
+
+            # Match OCR words whose center falls within this cell
+            text = ""
+            if ocr_words:
+                matched = []
+                for wx1, wy1, wx2, wy2, wtext in ocr_words:
+                    wcy = (wy1 + wy2) / 2
+                    wcx = (wx1 + wx2) / 2
+                    if cell_x1 <= wcx <= cell_x2 and cell_y1 <= wcy <= cell_y2:
+                        matched.append((wx1, wtext))
+                matched.sort(key=lambda x: x[0])
+                text = " ".join(t for _, t in matched)
+
+            cells.append(
+                TableCell(
+                    row=row_idx,
+                    col=col_idx,
+                    row_span=1,
+                    col_span=1,
+                    text=text,
+                    cell_type=cell_type,
+                    bbox=bbox,
+                )
+            )
+
+    return TableOutput(
+        cells=cells,
+        num_rows=len(rows),
+        num_cols=len(cols),
+        image_width=image_width,
+        image_height=image_height,
+        model_name=model_name,
+    )

--- a/tests/inference/modal_runner.py
+++ b/tests/inference/modal_runner.py
@@ -155,6 +155,7 @@ CPU_IMAGE = (
         ignore=["**/__pycache__", "**/*.pyc", "**/.git", "**/.venv", "**/.*"],
     )
     .run_commands("uv pip install '/opt/omnidocs[ocr]' --system")
+    .run_commands("uv pip install onnxruntime onnxscript --system")
     .add_local_dir(
         str(SCRIPTS_DIR),
         remote_path="/opt/test_scripts",

--- a/tests/inference/registry.py
+++ b/tests/inference/registry.py
@@ -481,6 +481,31 @@ TEST_REGISTRY: List[TestSpec] = [
         gpu_type=None,
         tags=["tableformer", "transformer"],
     ),
+    # TATR
+    TestSpec(
+        name="tatr_pytorch_gpu",
+        module="table_extraction.tatr_pytorch_gpu",
+        backend=Backend.PYTORCH_GPU,
+        task=Task.TABLE,
+        gpu_type="T4:1",
+        tags=["tatr", "transformer", "microsoft"],
+    ),
+    TestSpec(
+        name="tatr_pytorch_cpu",
+        module="table_extraction.tatr_pytorch_cpu",
+        backend=Backend.PYTORCH_CPU,
+        task=Task.TABLE,
+        gpu_type=None,
+        tags=["tatr", "transformer", "microsoft"],
+    ),
+    TestSpec(
+        name="tatr_onnx_cpu",
+        module="table_extraction.tatr_onnx_cpu",
+        backend=Backend.PYTORCH_CPU,  # no torch at inference, but export needs it; CPU bucket
+        task=Task.TABLE,
+        gpu_type=None,
+        tags=["tatr", "onnx", "microsoft"],
+    ),
     # ============================================================
     # READING ORDER
     # ============================================================

--- a/tests/inference/scripts/table_extraction/tatr_onnx_cpu.py
+++ b/tests/inference/scripts/table_extraction/tatr_onnx_cpu.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""TATR table extraction - ONNX CPU."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from helpers import Timer, create_table_image, print_result, verify_table_result
+
+img = create_table_image(rows=4, cols=3)
+
+from omnidocs.tasks.table_extraction import TATRExtractor
+from omnidocs.tasks.table_extraction.tatr import TATRONNXConfig, TATRVariant
+
+with Timer("Model load + export") as t_load:
+    extractor = TATRExtractor(backend=TATRONNXConfig(variant=TATRVariant.ALL, use_gpu=False))
+
+with Timer("Inference") as t_infer:
+    result = extractor.extract(img)
+
+verify_table_result(result)
+print_result(
+    "tatr_onnx_cpu",
+    {
+        "model": f"TATR-{TATRVariant.ALL.value}",
+        "backend": "onnx",
+        "num_cells": len(result.cells),
+        "grid": f"{result.num_rows}x{result.num_cols}",
+        "load_time": f"{t_load.elapsed:.2f}s",
+        "inference_time": f"{t_infer.elapsed:.2f}s",
+    },
+)

--- a/tests/inference/scripts/table_extraction/tatr_pytorch_cpu.py
+++ b/tests/inference/scripts/table_extraction/tatr_pytorch_cpu.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""TATR table extraction - PyTorch CPU."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from helpers import Timer, create_table_image, print_result, verify_table_result
+
+img = create_table_image(rows=4, cols=3)
+
+from omnidocs.tasks.table_extraction import TATRExtractor
+from omnidocs.tasks.table_extraction.tatr import TATRPyTorchConfig, TATRVariant
+
+with Timer("Model load") as t_load:
+    extractor = TATRExtractor(backend=TATRPyTorchConfig(device="cpu", variant=TATRVariant.ALL))
+
+with Timer("Inference") as t_infer:
+    result = extractor.extract(img)
+
+verify_table_result(result)
+print_result(
+    "tatr_pytorch_cpu",
+    {
+        "model": f"TATR-{TATRVariant.ALL.value}",
+        "backend": "pytorch",
+        "num_cells": len(result.cells),
+        "grid": f"{result.num_rows}x{result.num_cols}",
+        "load_time": f"{t_load.elapsed:.2f}s",
+        "inference_time": f"{t_infer.elapsed:.2f}s",
+    },
+)

--- a/tests/inference/scripts/table_extraction/tatr_pytorch_gpu.py
+++ b/tests/inference/scripts/table_extraction/tatr_pytorch_gpu.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""TATR table extraction - PyTorch GPU."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from helpers import Timer, check_gpu_available, create_table_image, print_result, verify_table_result
+
+check_gpu_available()
+img = create_table_image(rows=4, cols=3)
+
+from omnidocs.tasks.table_extraction import TATRExtractor
+from omnidocs.tasks.table_extraction.tatr import TATRPyTorchConfig, TATRVariant
+
+with Timer("Model load") as t_load:
+    extractor = TATRExtractor(backend=TATRPyTorchConfig(device="cuda", variant=TATRVariant.ALL))
+
+with Timer("Inference") as t_infer:
+    result = extractor.extract(img)
+
+verify_table_result(result)
+print_result(
+    "tatr_pytorch_gpu",
+    {
+        "model": f"TATR-{TATRVariant.ALL.value}",
+        "backend": "pytorch",
+        "num_cells": len(result.cells),
+        "grid": f"{result.num_rows}x{result.num_cols}",
+        "load_time": f"{t_load.elapsed:.2f}s",
+        "inference_time": f"{t_infer.elapsed:.2f}s",
+    },
+)

--- a/tests/tasks/table_extraction/test_tatr.py
+++ b/tests/tasks/table_extraction/test_tatr.py
@@ -1,0 +1,712 @@
+"""
+Tests for TATR (Table Transformer) extractor configuration and internals.
+
+Covers:
+  - TATRVariant enum
+  - TATRPyTorchConfig
+  - TATRONNXConfig
+  - TATRExtractor backend dispatch
+  - _detections_to_table_output grid reconstruction logic
+  - ONNX preprocessing helpers
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+
+from omnidocs.tasks.table_extraction.models import CellType
+from omnidocs.tasks.table_extraction.tatr import (
+    TATRExtractor,
+    TATRONNXConfig,
+    TATRPyTorchConfig,
+    TATRVariant,
+)
+from omnidocs.tasks.table_extraction.tatr.onnx import (
+    _box_cxcywh_to_xyxy,
+    _preprocess,
+    _sigmoid,
+)
+from omnidocs.tasks.table_extraction.tatr.pytorch import (
+    _detections_to_table_output,
+    _resolve_device,
+)
+
+# ===========================================================================
+# TATRVariant
+# ===========================================================================
+
+
+class TestTATRVariant:
+    """Tests for TATRVariant enum."""
+
+    def test_variant_values(self):
+        """Test that TATRVariant has expected values."""
+        assert TATRVariant.PUB.value == "pub"
+        assert TATRVariant.FIN.value == "fin"
+        assert TATRVariant.ALL.value == "all"
+
+    def test_variant_is_string_enum(self):
+        """Test that TATRVariant can be used as string."""
+        assert str(TATRVariant.ALL.value) == "all"
+
+    def test_variant_from_string(self):
+        """Test constructing variant from plain string."""
+        assert TATRVariant("pub") == TATRVariant.PUB
+        assert TATRVariant("fin") == TATRVariant.FIN
+        assert TATRVariant("all") == TATRVariant.ALL
+
+
+# ===========================================================================
+# TATRPyTorchConfig
+# ===========================================================================
+
+
+class TestTATRPyTorchConfig:
+    """Tests for TATRPyTorchConfig model."""
+
+    def test_default_config(self):
+        """Test creating config with defaults."""
+        config = TATRPyTorchConfig()
+        assert config.variant == TATRVariant.ALL
+        assert config.device == "auto"
+        assert config.detection_threshold == 0.5
+        assert config.cache_dir is None
+
+    def test_repo_id_pub(self):
+        """Test repo_id for PUB variant."""
+        config = TATRPyTorchConfig(variant=TATRVariant.PUB)
+        assert config.repo_id == "microsoft/table-transformer-structure-recognition"
+
+    def test_repo_id_fin(self):
+        """Test repo_id for FIN variant."""
+        config = TATRPyTorchConfig(variant=TATRVariant.FIN)
+        assert config.repo_id == "microsoft/table-transformer-structure-recognition-v1.1-fin"
+
+    def test_repo_id_all(self):
+        """Test repo_id for ALL variant."""
+        config = TATRPyTorchConfig(variant=TATRVariant.ALL)
+        assert config.repo_id == "microsoft/table-transformer-structure-recognition-v1.1-all"
+
+    def test_valid_devices(self):
+        """Test that all allowed device values are accepted."""
+        for device in ["cpu", "cuda", "mps", "auto"]:
+            config = TATRPyTorchConfig(device=device)
+            assert config.device == device
+
+    def test_invalid_device_raises(self):
+        """Test that an invalid device raises a ValidationError."""
+        with pytest.raises(ValidationError):
+            TATRPyTorchConfig(device="tpu")
+
+    def test_detection_threshold_bounds(self):
+        """Test detection_threshold must be in [0, 1]."""
+        TATRPyTorchConfig(detection_threshold=0.0)
+        TATRPyTorchConfig(detection_threshold=1.0)
+
+        with pytest.raises(ValidationError):
+            TATRPyTorchConfig(detection_threshold=-0.1)
+
+        with pytest.raises(ValidationError):
+            TATRPyTorchConfig(detection_threshold=1.1)
+
+    def test_cache_dir_optional(self):
+        """Test that cache_dir can be set or left as None."""
+        config = TATRPyTorchConfig(cache_dir="/tmp/models")
+        assert config.cache_dir == "/tmp/models"
+
+    def test_extra_fields_forbidden(self):
+        """Test that extra fields are rejected."""
+        with pytest.raises(ValidationError):
+            TATRPyTorchConfig(unknown_param="x")
+
+    def test_variant_from_string(self):
+        """Test that variant can be supplied as a plain string."""
+        config = TATRPyTorchConfig(variant="pub")
+        assert config.variant == TATRVariant.PUB
+
+    def test_full_config(self):
+        """Test creating config with all fields specified."""
+        config = TATRPyTorchConfig(
+            variant=TATRVariant.FIN,
+            device="cuda",
+            detection_threshold=0.7,
+            cache_dir="/custom/cache",
+        )
+        assert config.variant == TATRVariant.FIN
+        assert config.device == "cuda"
+        assert config.detection_threshold == 0.7
+        assert config.cache_dir == "/custom/cache"
+
+
+# ===========================================================================
+# TATRONNXConfig
+# ===========================================================================
+
+
+class TestTATRONNXConfig:
+    """Tests for TATRONNXConfig model."""
+
+    def test_default_config(self):
+        """Test creating ONNX config with defaults."""
+        config = TATRONNXConfig()
+        assert config.variant == TATRVariant.ALL
+        assert config.use_gpu is False
+        assert config.detection_threshold == 0.5
+        assert config.cache_dir is None
+
+    def test_repo_id_variants(self):
+        """Test repo_id property for all variants."""
+        assert "structure-recognition" in TATRONNXConfig(variant=TATRVariant.PUB).repo_id
+        assert "fin" in TATRONNXConfig(variant=TATRVariant.FIN).repo_id
+        assert "all" in TATRONNXConfig(variant=TATRVariant.ALL).repo_id
+
+    def test_use_gpu_flag(self):
+        """Test toggling use_gpu."""
+        assert TATRONNXConfig(use_gpu=True).use_gpu is True
+        assert TATRONNXConfig(use_gpu=False).use_gpu is False
+
+    def test_detection_threshold_bounds(self):
+        """Test detection_threshold must be in [0, 1]."""
+        TATRONNXConfig(detection_threshold=0.0)
+        TATRONNXConfig(detection_threshold=1.0)
+
+        with pytest.raises(ValidationError):
+            TATRONNXConfig(detection_threshold=1.5)
+
+        with pytest.raises(ValidationError):
+            TATRONNXConfig(detection_threshold=-0.5)
+
+    def test_cache_dir(self):
+        """Test cache_dir field."""
+        config = TATRONNXConfig(cache_dir="/onnx/cache")
+        assert config.cache_dir == "/onnx/cache"
+
+    def test_extra_fields_forbidden(self):
+        """Test that extra fields are rejected."""
+        with pytest.raises(ValidationError):
+            TATRONNXConfig(does_not_exist=True)
+
+    def test_full_config(self):
+        """Test full ONNX config construction."""
+        config = TATRONNXConfig(
+            variant=TATRVariant.PUB,
+            use_gpu=True,
+            detection_threshold=0.3,
+            cache_dir="/some/path",
+        )
+        assert config.variant == TATRVariant.PUB
+        assert config.use_gpu is True
+        assert config.detection_threshold == 0.3
+        assert config.cache_dir == "/some/path"
+
+
+# ===========================================================================
+# TATRExtractor — backend dispatch
+# ===========================================================================
+
+
+class TestTATRExtractorDispatch:
+    """Tests for TATRExtractor backend selection."""
+
+    def test_pytorch_backend_selected(self):
+        """Test that TATRPyTorchConfig routes to TATRPyTorchExtractor."""
+        from omnidocs.tasks.table_extraction.tatr.pytorch import TATRPyTorchExtractor
+
+        config = TATRPyTorchConfig()
+        with patch.object(TATRPyTorchExtractor, "_load_model", return_value=None):
+            extractor = TATRExtractor(backend=config)
+            assert isinstance(extractor._impl, TATRPyTorchExtractor)
+
+    def test_onnx_backend_selected(self):
+        """Test that TATRONNXConfig routes to TATRONNXExtractor."""
+        from omnidocs.tasks.table_extraction.tatr.onnx import TATRONNXExtractor
+
+        config = TATRONNXConfig()
+        with patch.object(TATRONNXExtractor, "_load_model", return_value=None):
+            extractor = TATRExtractor(backend=config)
+            assert isinstance(extractor._impl, TATRONNXExtractor)
+
+    def test_unknown_backend_raises(self):
+        """Test that an unrecognised backend type raises TypeError."""
+        from omnidocs.tasks.table_extraction.tatr.pytorch import TATRPyTorchExtractor
+
+        config = TATRPyTorchConfig()
+        with patch.object(TATRPyTorchExtractor, "_load_model", return_value=None):
+            ext = TATRExtractor(backend=config)
+            with pytest.raises(TypeError, match="Unknown TATR backend"):
+                ext._build_impl("not-a-config")
+
+    def test_backend_config_stored(self):
+        """Test that backend_config is stored on the extractor."""
+        from omnidocs.tasks.table_extraction.tatr.pytorch import TATRPyTorchExtractor
+
+        config = TATRPyTorchConfig(variant=TATRVariant.FIN)
+        with patch.object(TATRPyTorchExtractor, "_load_model", return_value=None):
+            extractor = TATRExtractor(backend=config)
+            assert extractor.backend_config is config
+
+
+# ===========================================================================
+# _resolve_device helper
+# ===========================================================================
+
+
+class TestResolveDevice:
+    """Tests for _resolve_device helper function."""
+
+    def test_explicit_cpu(self):
+        assert _resolve_device("cpu") == "cpu"
+
+    def test_explicit_cuda(self):
+        assert _resolve_device("cuda") == "cuda"
+
+    def test_explicit_mps(self):
+        assert _resolve_device("mps") == "mps"
+
+    def test_auto_falls_back_to_cpu_when_torch_absent(self):
+        """When torch is not importable, auto should resolve to cpu."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "torch":
+                raise ImportError("no torch")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = _resolve_device("auto")
+        assert result == "cpu"
+
+    def test_auto_resolves_to_cuda_when_available(self):
+        """When CUDA is available, auto should resolve to cuda."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            result = _resolve_device("auto")
+        assert result == "cuda"
+
+    def test_auto_resolves_to_mps_when_cuda_unavailable(self):
+        """When CUDA is unavailable but MPS is, auto should resolve to mps."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = True
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            result = _resolve_device("auto")
+        assert result == "mps"
+
+
+# ===========================================================================
+# _detections_to_table_output (unit — no model weights)
+# ===========================================================================
+
+_LABEL_MAP = {
+    0: "table",
+    1: "table column",
+    2: "table row",
+    3: "table column header",
+    4: "table projected row header",
+    5: "table spanning cell",
+    6: "no object",
+}
+
+
+class TestDetectionsToTableOutput:
+    """Tests for the TATR grid reconstruction helper."""
+
+    def _boxes_scores_labels(self, rows, cols, header_rows=None):
+        """Build raw detection lists for given row/col bboxes."""
+        boxes, scores, labels = [], [], []
+        for r in rows:
+            boxes.append(list(r))
+            scores.append(0.9)
+            labels.append(2)  # "table row"
+        for c in cols:
+            boxes.append(list(c))
+            scores.append(0.9)
+            labels.append(1)  # "table column"
+        if header_rows:
+            for hr in header_rows:
+                boxes.append(list(hr))
+                scores.append(0.9)
+                labels.append(3)  # "table column header"
+        return boxes, scores, labels
+
+    def test_empty_detections_returns_empty_table(self):
+        """No rows or columns → empty TableOutput."""
+        result = _detections_to_table_output(
+            boxes=[],
+            scores=[],
+            labels=[],
+            image_width=800,
+            image_height=600,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 0
+        assert result.num_cols == 0
+        assert result.cell_count == 0
+
+    def test_no_rows_returns_empty_table(self):
+        """Columns but no rows → empty TableOutput."""
+        boxes = [[0, 0, 100, 200]]
+        scores = [0.9]
+        labels = [1]  # column only
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=800,
+            image_height=600,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 0
+        assert result.num_cols == 0
+
+    def test_no_cols_returns_empty_table(self):
+        """Rows but no columns → empty TableOutput."""
+        boxes = [[0, 0, 800, 50]]
+        scores = [0.9]
+        labels = [2]  # row only
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=800,
+            image_height=600,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 0
+        assert result.num_cols == 0
+
+    def test_2x2_grid_produces_4_cells(self):
+        """Two rows × two columns → 4 cells."""
+        rows = [(0, 0, 200, 50), (0, 50, 200, 100)]
+        cols = [(0, 0, 100, 100), (100, 0, 200, 100)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=100,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 2
+        assert result.num_cols == 2
+        assert result.cell_count == 4
+
+    def test_3x3_grid_cell_indices_correct(self):
+        """Verify row/col indices are assigned correctly for a 3×3 grid."""
+        rows = [(0, 0, 300, 50), (0, 50, 300, 100), (0, 100, 300, 150)]
+        cols = [(0, 0, 100, 150), (100, 0, 200, 150), (200, 0, 300, 150)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=300,
+            image_height=150,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 3
+        assert result.num_cols == 3
+        assert result.cell_count == 9
+
+        top_left = result.get_cell(0, 0)
+        assert top_left is not None
+        assert top_left.row == 0 and top_left.col == 0
+
+        bottom_right = result.get_cell(2, 2)
+        assert bottom_right is not None
+        assert bottom_right.row == 2 and bottom_right.col == 2
+
+    def test_column_header_row_sets_cell_type(self):
+        """Rows detected as column headers should produce COLUMN_HEADER cells."""
+        boxes = [
+            [0, 0, 200, 40],  # label 3 → column header
+            [0, 40, 200, 80],  # label 2 → regular row
+            [0, 0, 200, 80],  # label 1 → column
+        ]
+        scores = [0.9, 0.9, 0.9]
+        labels = [3, 2, 1]
+
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=80,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        header_cells = [c for c in result.cells if c.cell_type == CellType.COLUMN_HEADER]
+        assert len(header_cells) > 0
+
+    def test_model_name_stored(self):
+        """Verify model_name is propagated to TableOutput."""
+        rows = [(0, 0, 100, 50)]
+        cols = [(0, 0, 100, 50)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=100,
+            image_height=50,
+            ocr_output=None,
+            model_name="TATR-all",
+            label_map=_LABEL_MAP,
+        )
+        assert result.model_name == "TATR-all"
+
+    def test_image_dimensions_stored(self):
+        """Verify image dimensions are propagated to TableOutput."""
+        rows = [(0, 0, 640, 50)]
+        cols = [(0, 0, 640, 50)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=640,
+            image_height=480,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.image_width == 640
+        assert result.image_height == 480
+
+    def test_non_overlapping_row_col_skipped(self):
+        """A row/col pair that doesn't overlap should not produce a cell."""
+        row = (100, 0, 200, 50)  # x: 100–200
+        col = (0, 0, 50, 50)  # x: 0–50 — no overlap
+        boxes, scores, labels = self._boxes_scores_labels([row], [col])
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=50,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.cell_count == 0
+
+    def test_ocr_text_matched_to_cell(self):
+        """Words whose centres fall inside a cell are assigned to it."""
+        from omnidocs.tasks.table_extraction.models import BoundingBox
+
+        row = (0, 0, 200, 50)
+        col = (0, 0, 200, 50)
+        boxes, scores, labels = self._boxes_scores_labels([row], [col])
+
+        word_bbox = BoundingBox(x1=80, y1=15, x2=120, y2=35)
+        block = MagicMock()
+        block.bbox = word_bbox
+        block.text = "Hello"
+
+        ocr_output = MagicMock()
+        ocr_output.text_blocks = [block]
+
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=50,
+            ocr_output=ocr_output,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.cell_count == 1
+        assert result.cells[0].text == "Hello"
+
+    def test_rows_sorted_top_to_bottom(self):
+        """Rows should be sorted by y1 after grid reconstruction."""
+        rows = [(0, 100, 200, 150), (0, 0, 200, 50), (0, 50, 200, 100)]
+        cols = [(0, 0, 200, 150)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=150,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_rows == 3
+        row_indices = [c.row for c in result.cells]
+        assert row_indices == sorted(row_indices)
+
+    def test_cols_sorted_left_to_right(self):
+        """Columns should be sorted by x1 after grid reconstruction."""
+        cols = [(200, 0, 300, 100), (0, 0, 100, 100), (100, 0, 200, 100)]
+        rows = [(0, 0, 300, 100)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=300,
+            image_height=100,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.num_cols == 3
+        col_indices = [c.col for c in result.cells]
+        assert col_indices == sorted(col_indices)
+
+    def test_default_cell_type_is_data(self):
+        """Non-header rows should produce DATA cells."""
+        rows = [(0, 0, 200, 50)]
+        cols = [(0, 0, 200, 50)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=50,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.cells[0].cell_type == CellType.DATA
+
+    def test_cell_spans_are_1_by_default(self):
+        """All cells should have row_span=1 and col_span=1 from grid logic."""
+        rows = [(0, 0, 200, 50), (0, 50, 200, 100)]
+        cols = [(0, 0, 100, 100), (100, 0, 200, 100)]
+        boxes, scores, labels = self._boxes_scores_labels(rows, cols)
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=100,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        for cell in result.cells:
+            assert cell.row_span == 1
+            assert cell.col_span == 1
+
+    def test_cell_bbox_is_intersection(self):
+        """Cell bbox should equal the intersection of its row and column boxes."""
+        row = (10, 20, 200, 70)  # x: 10–200, y: 20–70
+        col = (50, 0, 150, 100)  # x: 50–150, y: 0–100
+        boxes, scores, labels = self._boxes_scores_labels([row], [col])
+        result = _detections_to_table_output(
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            image_width=200,
+            image_height=100,
+            ocr_output=None,
+            model_name="test",
+            label_map=_LABEL_MAP,
+        )
+        assert result.cell_count == 1
+        bbox = result.cells[0].bbox
+        assert bbox.x1 == 50  # max(10, 50)
+        assert bbox.y1 == 20  # max(20, 0)
+        assert bbox.x2 == 150  # min(200, 150)
+        assert bbox.y2 == 70  # min(70, 100)
+
+
+# ===========================================================================
+# ONNX preprocessing helpers
+# ===========================================================================
+
+
+class TestONNXPreprocess:
+    """Tests for ONNX preprocessing utilities."""
+
+    def test_preprocess_output_shape(self):
+        """_preprocess should return (1, 3, 800, 800) float32."""
+        img = Image.new("RGB", (640, 480), color=(128, 64, 32))
+        arr = _preprocess(img)
+        assert arr.shape == (1, 3, 800, 800)
+        assert arr.dtype == np.float32
+
+    def test_preprocess_normalised_range(self):
+        """After ImageNet normalisation, black pixels should be negative."""
+        img = Image.new("RGB", (100, 100), color=(0, 0, 0))
+        arr = _preprocess(img)
+        assert arr.min() < 0
+
+    def test_sigmoid_zero(self):
+        """sigmoid(0) should be ~0.5."""
+        result = _sigmoid(np.array([0.0]))
+        assert abs(result[0] - 0.5) < 1e-6
+
+    def test_sigmoid_large_positive(self):
+        """sigmoid(100) should be ~1.0."""
+        result = _sigmoid(np.array([100.0]))
+        assert result[0] > 0.999
+
+    def test_sigmoid_large_negative(self):
+        """sigmoid(-100) should be ~0.0."""
+        result = _sigmoid(np.array([-100.0]))
+        assert result[0] < 0.001
+
+    def test_sigmoid_batch(self):
+        """sigmoid applied to a batch preserves shape and is monotonically increasing."""
+        x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+        result = _sigmoid(x)
+        assert result.shape == x.shape
+        assert list(result) == sorted(result)
+
+    def test_box_cxcywh_to_xyxy_basic(self):
+        """Test center-format to corner-format conversion: cx=50,cy=50,w=100,h=80."""
+        boxes = np.array([[50.0, 50.0, 100.0, 80.0]])
+        result = _box_cxcywh_to_xyxy(boxes)
+        assert result.shape == (1, 4)
+        assert abs(result[0, 0] - 0.0) < 1e-5  # x1 = cx - w/2
+        assert abs(result[0, 1] - 10.0) < 1e-5  # y1 = cy - h/2
+        assert abs(result[0, 2] - 100.0) < 1e-5  # x2 = cx + w/2
+        assert abs(result[0, 3] - 90.0) < 1e-5  # y2 = cy + h/2
+
+    def test_box_cxcywh_to_xyxy_batch_shape(self):
+        """Batch conversion preserves shape."""
+        boxes = np.random.rand(5, 4).astype(np.float32)
+        result = _box_cxcywh_to_xyxy(boxes)
+        assert result.shape == (5, 4)
+
+    def test_box_cxcywh_to_xyxy_width_height_preserved(self):
+        """Converted box width and height should equal original w/h."""
+        boxes = np.array([[100.0, 100.0, 60.0, 40.0]])
+        result = _box_cxcywh_to_xyxy(boxes)
+        w = result[0, 2] - result[0, 0]
+        h = result[0, 3] - result[0, 1]
+        assert abs(w - 60.0) < 1e-5
+        assert abs(h - 40.0) < 1e-5
+
+    def test_box_cxcywh_to_xyxy_center_preserved(self):
+        """The centre of the converted box should equal the original cx/cy."""
+        boxes = np.array([[200.0, 150.0, 80.0, 60.0]])
+        result = _box_cxcywh_to_xyxy(boxes)
+        cx = (result[0, 0] + result[0, 2]) / 2
+        cy = (result[0, 1] + result[0, 3]) / 2
+        assert abs(cx - 200.0) < 1e-5
+        assert abs(cy - 150.0) < 1e-5


### PR DESCRIPTION
## Description
Adds Microsoft's Table Transformer (TATR) as a new table structure extraction backend. TATR is a DETR-based object detection model that detects table rows, columns, and cell bounding boxes from document images. The implementation provides two runtime backends (PyTorch and ONNX) and three model variants tuned for different document types.

## Changes Made
- omnidocs/tasks/table_extraction/tatr/ — New TATR module with four files:
    - config.py — TATRVariant enum (pub, fin, all) and Pydantic configs TATRPyTorchConfig / TATRONNXConfig with validation for device, threshold, cache dir, and HuggingFace repo routing

    - pytorch.py — TATRPyTorchExtractor using HuggingFace TableTransformerForObjectDetection; includes _resolve_device auto-detection (CUDA → MPS → CPU), model caching, and two workarounds for huggingface_hub >=0.24 strict validation bugs; shared _detections_to_table_output grid-reconstruction helper (row × column intersection → TableOutput)

    - onnx.py — TATRONNXExtractor that exports the HuggingFace model to ONNX on first use (cached to disk) then runs inference via onnxruntime with no PyTorch dependency; includes manual ImageNet preprocessing and DETR box conversion

    - extractor.py — TATRExtractor unified entry point that dispatches to the correct backend based on config type; exposes extract and batch_extract


- tests/tasks/table_extraction/test_tatr.py — Unit test suite (no model weights required) covering: TATRVariant, TATRPyTorchConfig, TATRONNXConfig, TATRExtractor backend dispatch, _detections_to_table_output grid reconstruction (empty cases, 2×2, 3×3, header rows, OCR text matching, non-overlapping boxes, cell bbox intersection, sort order), and ONNX preprocessing helpers (_preprocess, _sigmoid, _box_cxcywh_to_xyxy)

- tests/inference/scripts/table_extraction/ — Three end-to-end inference smoke scripts:

    - tatr_pytorch_cpu.py — PyTorch CPU inference
    - tatr_pytorch_gpu.py — PyTorch CUDA inference (with GPU availability check)
    - tatr_onnx_cpu.py — ONNX CPU inference (exercises export-on-first-use path)

- Updated docs
## Testing
<!-- How was this tested? -->
- [x] Tests added/updated
- [x] All tests passing locally (`uv run pytest tests/ -v`)
- [x] Linting passes (`uv run ruff check .` and `uv run ruff format .`)

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (if needed)
- [x] CONTRIBUTING.md guidelines followed
